### PR TITLE
Use post import deeplink

### DIFF
--- a/examples/postbox/index.js
+++ b/examples/postbox/index.js
@@ -14,7 +14,7 @@ app.use(express.static(__dirname + '/assets'));
 
 // If you need or want to specify different initialization options you can create the SDK like this:
 // const { createSDK } = require("@digime/digime-js-sdk");
-// const { establishSession, getWebURL, getDataForSession, getAppURL } = createSDK({ host: "api.digi.me" });
+// const { establishSession, getPostboxURL, pushDataToPostbox } = createSDK({ host: "api.digi.me" });
 
 // Since we do not need to specify different initialization options we will import the functions directly:
 const { establishSession, getPostboxURL, pushDataToPostbox } = require("@digime/digime-js-sdk");

--- a/examples/postbox/views/pages/return.ejs
+++ b/examples/postbox/views/pages/return.ejs
@@ -14,7 +14,7 @@
             Your purchase receipt has been sent, please check and sync your digi.me library.
         </p>
 
-        <a class="cta-button" href="digime://" style="width: 267px">
+        <a class="cta-button" href="digime://postbox/import" style="width: 267px">
             Open digi.me
         </a>
     </div>


### PR DESCRIPTION
This commit will use the postbox/import deeplink to open the client once
the receipt has been pushed into user's digi.me.

This triggers a postbox import in the client application straight away.

Also fixed is example code relating to customised endpoints for postbox.